### PR TITLE
Added unique_id

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -29,6 +29,7 @@ media_player:
       '1' : 'Stereo'
       'T' : 'Source Direct'
       'U' : 'Pure Direct'
+    unique_id: '12345'
 ```
 
 Configuration variables:
@@ -38,3 +39,4 @@ Configuration variables:
 - **name** (*Optional*): Name of the device. (default = 'Marantz Receiver')
 - **min_volume** (*Optional*): Minimal volume of the reciever, will also appear on the volume slider from 0-100% (default = '-71')
 - **max_volume** (*Optional*): Maximal volume of the reciever, will also appear on the volume slider from 0-100%  (default = '-1')
+- **unique_id** (*Optional*): Defines a unique_id used by HA to identify this specific unit

--- a/custom_components/marantzusb/manifest.json
+++ b/custom_components/marantzusb/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/Imperial-Guard/marantz_tcp",
   "dependencies": [],
   "codeowners": [],
-  "requirements": []
+  "requirements": [],
   "version": "1.0"
 }

--- a/custom_components/marantzusb/media_player.py
+++ b/custom_components/marantzusb/media_player.py
@@ -11,11 +11,8 @@ import voluptuous as vol
 from homeassistant.components.media_player import (
     MediaPlayerEntity,
     PLATFORM_SCHEMA)
-from homeassistant.components.media_player.const import (
-    SUPPORT_VOLUME_SET,
-    SUPPORT_VOLUME_MUTE, SUPPORT_TURN_ON, SUPPORT_TURN_OFF,
-    SUPPORT_VOLUME_STEP, SUPPORT_SELECT_SOURCE, SUPPORT_SELECT_SOUND_MODE
-)
+from homeassistant.components.media_player import MediaPlayerEntityFeature
+
 from homeassistant.const import (
     CONF_NAME, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
@@ -26,9 +23,9 @@ DEFAULT_NAME = 'Marantz Receiver'
 DEFAULT_MIN_VOLUME = -71
 DEFAULT_MAX_VOLUME = -1
 
-SUPPORT_MARANTZ = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
-    SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_VOLUME_STEP | \
-    SUPPORT_SELECT_SOURCE | SUPPORT_SELECT_SOUND_MODE 
+SUPPORT_MARANTZ = MediaPlayerEntityFeature.VOLUME_SET | MediaPlayerEntityFeature.VOLUME_MUTE | \
+    MediaPlayerEntityFeature.TURN_ON | MediaPlayerEntityFeature.TURN_OFF | MediaPlayerEntityFeature.VOLUME_STEP | \
+    MediaPlayerEntityFeature.SELECT_SOURCE | MediaPlayerEntityFeature.SELECT_SOUND_MODE 
 
 CONF_SERIAL_PORT = 'serial_port'
 CONF_MIN_VOLUME = 'min_volume'

--- a/custom_components/marantzusb/media_player.py
+++ b/custom_components/marantzusb/media_player.py
@@ -35,6 +35,7 @@ CONF_MIN_VOLUME = 'min_volume'
 CONF_MAX_VOLUME = 'max_volume'
 CONF_SOURCE_DICT = 'sources'
 CONF_SOUNDMODE_DICT = 'soundmode'
+CONF_UNIQUE_ID = 'unique_id'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SERIAL_PORT): cv.string,
@@ -43,6 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MAX_VOLUME, default=DEFAULT_MAX_VOLUME): int,
     vol.Optional(CONF_SOURCE_DICT, default={}): {cv.string: cv.string},
     vol.Optional(CONF_SOUNDMODE_DICT, default={}): {cv.string: cv.string},
+    vol.Optional(CONF_UNIQUE_ID, default=''): cv.string,
 })
 
 
@@ -55,7 +57,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         config.get(CONF_MIN_VOLUME),
         config.get(CONF_MAX_VOLUME),
         config.get(CONF_SOURCE_DICT),
-        config.get(CONF_SOUNDMODE_DICT)
+        config.get(CONF_SOUNDMODE_DICT),
+        config.get(CONF_UNIQUE_ID)
     )], True)
 
 
@@ -63,7 +66,7 @@ class Marantz(MediaPlayerEntity):
     """Representation of a Marantz Receiver."""
 
     def __init__(self, name, marantz_receiver, min_volume, max_volume,
-                 source_dict, sound_mode_dict):
+                 source_dict, sound_mode_dict, unique_id):
         """Initialize the Marantz Receiver device."""
         self._name = name
         self._marantz_receiver = marantz_receiver
@@ -75,6 +78,7 @@ class Marantz(MediaPlayerEntity):
                                  self._source_dict.items()}
         self._reverse_mapping_sound_mode = {value: "0{}".format(key) for key, value in
                                  self._sound_mode_dict.items()}
+        self._unique_id = unique_id
 
         self._volume = self._state = self._mute = self._source = None
 
@@ -197,3 +201,8 @@ class Marantz(MediaPlayerEntity):
     def sound_mode_list(self):
         """List of available sound_modes."""
         return sorted(list(self._reverse_mapping_sound_mode.keys()))
+
+    @property
+    def unique_id(self):
+        return self._unique_id
+


### PR DESCRIPTION
By letting the Marantz class expose the unique_id property, HA will allow more functionality through its UI, such as assigning the device to an area and setting an icon. 

Also fixed a syntax error in the JSON manifest which caused it to not parse correctly.